### PR TITLE
Fix meta file artifact extension

### DIFF
--- a/META
+++ b/META
@@ -1,5 +1,5 @@
 version = "0.1"
 description = "SDK for making Merlin extensions"
 
-archive(byte) = "merlin_extend.cmo"
-archive(native) = "merlin_extend.cmx"
+archive(byte) = "merlin_extend.cma"
+archive(native) = "merlin_extend.cmxa"


### PR DESCRIPTION
Opam, during/after make, complains that `merlin_extend.cma` can't be found. Which can be traced back here.
