### PR TITLE
Remove inline cppo directive

### DIFF
--- a/extend_helper.cppo.ml
+++ b/extend_helper.cppo.ml
@@ -1,4 +1,3 @@
-(*pp cppo -V OCAML:`ocamlc -version` *)
 open Parsetree
 open Extend_protocol
 


### PR DESCRIPTION
First off, thank you for your work on `merlin-extend`!

I'm working on adding Windows support to https://github.com/esy/esy, and one issue we're encountering is a compilation error with `cppo`. Specifically, it seems to have difficulty handling the backticks or shelling out to `ocamlc -version` on Windows. I've logged an issue here: mjambon/cppo#60 

However, it seems that this pre-processing may not even be necessary since the project was migrated to jbuilder. The `cppo` pre-processing step is also run as an action in the `jbuild` file:
https://github.com/let-def/merlin-extend/blob/60720e237cd83650028e9a03d89a5e49c93e6d31/jbuild#L6

Thus, a simple fix is to remove the pre-processing step in the file, since it seems redundant given the `jbuild` strategy.