### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/dune
+++ b/dune
@@ -7,7 +7,7 @@
 (library
  (name merlin_extend)
  (public_name merlin-extend)
- (libraries compiler-libs)
+ (libraries compiler-libs unix)
  (flags
   (:standard -w -50))
  (wrapped false))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.